### PR TITLE
fix: remove default behaviour of ruamel.yaml line breaking

### DIFF
--- a/.github/workflows/flit-release.yml
+++ b/.github/workflows/flit-release.yml
@@ -24,9 +24,16 @@ jobs:
     - name: Install flit
       run: |
         pip install flit>=3.9.0
+
     - name: Build and publish
       run: |
-        flit publish
+        flit publish --no-use-vcs
       env:
         FLIT_USERNAME: __token__
         FLIT_PASSWORD: ${{ secrets.PYPI_KEY }}
+
+    - name: check files
+      if: always()
+      run: |
+        ls -alh
+        ls -alh *.*

--- a/mdformat_frontmatter/plugin.py
+++ b/mdformat_frontmatter/plugin.py
@@ -1,4 +1,5 @@
 import io
+import sys
 from typing import Mapping
 
 from markdown_it import MarkdownIt
@@ -11,6 +12,7 @@ import ruamel.yaml
 yaml = ruamel.yaml.YAML()
 # Make sure to always have `sequence >= offset + 2`
 yaml.indent(mapping=2, sequence=4, offset=2)
+yaml.width = sys.maxsize
 
 
 def update_mdit(mdit: MarkdownIt) -> None:
@@ -36,4 +38,5 @@ def _render_frontmatter(node: RenderTreeNode, context: RenderContext) -> str:
     return node.markup + "\n" + formatted_yaml + node.markup
 
 
+# apply the render function to the block identified by the mdit plugin
 RENDERERS: Mapping[str, Render] = {"front_matter": _render_frontmatter}

--- a/tests/fixtures.md
+++ b/tests/fixtures.md
@@ -102,3 +102,14 @@ Dont format.
 Dont format.
 ---
 .
+
+Test long line endings
+.
+---
+somethingthatis: reallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallylong
+---
+.
+---
+somethingthatis: reallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallylong
+---
+.


### PR DESCRIPTION
- fix(cicd): Correct flit behaviour to just work
- feat: Ensure that ruamel.yaml does not wrap lines
