### PR TITLE
feat: support mdformat 1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ keywords = [
 ]
 dynamic = ["version", "description"]
 
-requires-python=">=3.7"
-dependencies=["mdformat >=0.7.16,<0.8.0",
+requires-python=">=3.10"
+dependencies=["mdformat >=0.7.16",
           "mdit-py-plugins >=0.4.0",
           "ruamel.yaml"
             ]


### PR DESCRIPTION
## Summary

- Remove upper bound on mdformat dependency (`>=0.7.16` instead of `>=0.7.16,<0.8.0`)
- Update `requires-python` to `>=3.10` (matches mdformat 1.0 requirement)

## Testing

All 10 tests pass with mdformat 1.0.0 on Python 3.14:

```
tests/test_fixtures.py::test_fixtures[a test] PASSED
tests/test_fixtures.py::test_fixtures[another test] PASSED
tests/test_fixtures.py::test_fixtures[Test yaml header] PASSED
tests/test_fixtures.py::test_fixtures[Test yaml reformat] PASSED
tests/test_fixtures.py::test_fixtures[CommonMark v0.29 spec example 66] PASSED
tests/test_fixtures.py::test_fixtures[CommonMark v0.29 spec example 68] PASSED
tests/test_fixtures.py::test_fixtures[YAML parse error] PASSED
tests/test_fixtures.py::test_fixtures[Test long line endings] PASSED
tests/test_fixtures.py::test_fixtures[YAML parse error duplicate keys] PASSED
tests/test_fixtures.py::test_simple_md PASSED
```

## Motivation

mdformat 1.0.0 was released Oct 16, 2025 with:
- Python ≥3.10 requirement
- LF line endings on all platforms
- Improved plugin interface

This PR enables mdformat-frontmatter to work with both mdformat 0.7.x and 1.x.