### PR TITLE
fix: preserve YAML string quotes in frontmatter

### DIFF
--- a/mdformat_frontmatter/plugin.py
+++ b/mdformat_frontmatter/plugin.py
@@ -10,6 +10,7 @@ from mdit_py_plugins.front_matter import front_matter_plugin
 import ruamel.yaml
 
 yaml = ruamel.yaml.YAML()
+yaml.preserve_quotes = True
 # Make sure to always have `sequence >= offset + 2`
 yaml.indent(mapping=2, sequence=4, offset=2)
 yaml.width = sys.maxsize


### PR DESCRIPTION
## Summary

Set `preserve_quotes=True` on the ruamel.yaml YAML instance so that quoted strings in frontmatter are preserved during round-trip formatting.

## Problem

Without this, ruamel.yaml strips "unnecessary" quotes from YAML string values:

```yaml
# Before mdformat
title: "My Post"

# After mdformat (current)
title: My Post
```

## Fix

One-line change in `plugin.py`:

```diff
 yaml = ruamel.yaml.YAML()
+yaml.preserve_quotes = True
```

With `preserve_quotes=True`, ruamel.yaml loads strings into special subclasses (`DoubleQuotedScalarString`, `SingleQuotedScalarString`) that preserve their original quote style when dumped back. This is the standard ruamel.yaml approach for lossless round-tripping.

Fixes #42