### PR TITLE
fix: use GITHUB_TOKEN instead of ADMIN_WRITE_PAT for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
-        token: ${{ secrets.ADMIN_WRITE_PAT }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
@@ -43,7 +43,7 @@ jobs:
       id: release
       uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
       with:
-        github_token: ${{ secrets.ADMIN_WRITE_PAT }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
@@ -59,4 +59,4 @@ jobs:
       uses: python-semantic-release/upload-to-gh-release@0a92b5d7ebfc15a84f9801ebd1bf706343d43711 # v9.8.9
       if: steps.release.outputs.released == 'true'
       with:
-        github_token: ${{ secrets.ADMIN_WRITE_PAT }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace ADMIN_WRITE_PAT with GITHUB_TOKEN in release workflow
- Fixes authentication errors from expired/insufficient PAT permissions
- Eliminates need to manage separate PAT secret

## Background
The release workflow failed with authentication error:
```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

The ADMIN_WRITE_PAT secret appears to be expired or has insufficient permissions.

## Solution
Since the release workflow already grants `contents: write` permission, the built-in GITHUB_TOKEN has all necessary permissions to:
- Create and push tags
- Update version files  
- Create GitHub releases
- Upload release artifacts

This change switches all three token usages in the workflow:
1. `actions/checkout` token parameter
2. `python-semantic-release` github_token parameter  
3. `upload-to-gh-release` github_token parameter

## Test plan
- [x] CI tests pass on this PR
- [ ] After merge: release workflow successfully publishes v2.1.0 to PyPI
- [ ] After merge: GitHub release created with signed artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)