### PR TITLE
fix: use GitHub App token to bypass branch protection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,16 @@ jobs:
       with:
         egress-policy: audit
 
+    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      id: app-token
+      with:
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.PRIVATE_KEY }}
+
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
 
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
@@ -43,7 +49,7 @@ jobs:
       id: release
       uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ steps.app-token.outputs.token }}
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
@@ -59,4 +65,4 @@ jobs:
       uses: python-semantic-release/upload-to-gh-release@0a92b5d7ebfc15a84f9801ebd1bf706343d43711 # v9.8.9
       if: steps.release.outputs.released == 'true'
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Replace GITHUB_TOKEN with GitHub App token in release workflow
- Fixes branch protection bypass issue preventing automated releases
- Follows compliance-trestle pattern for secure, automated releases

## Background
The release workflow failed with:
```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

GITHUB_TOKEN cannot bypass branch protection by design - this is a GitHub security feature. When semantic-release tries to push version bump commits directly to main, the protected branch rules block it.

## Solution
Use a GitHub App token instead of GITHUB_TOKEN. GitHub Apps with appropriate permissions can bypass branch protection when configured correctly.

This pattern is used by compliance-trestle and other mature projects. It's more secure than a personal access token because:
- Apps have granular permissions (only Contents: write needed)
- Can be scoped to specific repositories  
- Easier to audit and rotate
- No association with individual user accounts

## Changes
1. Add `actions/create-github-app-token@v3.2.0` step to generate app token
2. Update `actions/checkout` to use app token
3. Update `python-semantic-release` to use app token
4. Update `upload-to-gh-release` to use app token

## Prerequisites
The following secrets must be configured (already done):
- `APP_ID`: GitHub App ID
- `PRIVATE_KEY`: GitHub App private key (PEM format)

## Test plan
- [x] CI tests pass on this PR
- [ ] After merge: release workflow successfully publishes v2.1.0 to PyPI
- [ ] After merge: GitHub release created with signed artifacts
- [ ] After merge: version bump commit pushed directly to main (bypassing PR requirement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)